### PR TITLE
Use relative font-size instead of absolute

### DIFF
--- a/koj72yomi.cpp
+++ b/koj72yomi.cpp
@@ -716,13 +716,13 @@ int main()
 					// There is no way to detect what kanji the furigana should go over, so doing this instead
 					//		See: わそう‐コート 【和装コート】
 					// Example where having rubi formatting is important アートマン 【ātman 梵】
-					fnOpenReplace = "\", {\"tag\": \"span\", \"style\": {\"fontSize\": \"x-small\", \"verticalAlign\": \"bottom\"}, \"content\": \"";
+					fnOpenReplace = "\", {\"tag\": \"span\", \"style\": {\"fontSize\": \"smaller\", \"verticalAlign\": \"bottom\"}, \"content\": \"";
 					fnCloseReplace = "\"}, \"";
 				}
 				else if (tagAttributes == "")
 				{
 					// Plain ol subscript. Technically making this `bottom`, not sub (to match rubi)
-					fnOpenReplace = "\", {\"tag\": \"span\", \"style\": {\"fontSize\": \"x-small\", \"verticalAlign\": \"bottom\"}, \"content\": \"";
+					fnOpenReplace = "\", {\"tag\": \"span\", \"style\": {\"fontSize\": \"smaller\", \"verticalAlign\": \"bottom\"}, \"content\": \"";
 					fnCloseReplace = "\"}, \"";
 				}
 			}
@@ -730,13 +730,13 @@ int main()
 			{
 				// Seems to be used exactly the same as the sub with no attributes
 				// Fun Fact: literally the only two entries that have this are LC50 and LD50
-				fnOpenReplace = "\", {\"tag\": \"span\", \"style\": {\"fontSize\": \"x-small\", \"verticalAlign\": \"bottom\"}, \"content\": \"";
+				fnOpenReplace = "\", {\"tag\": \"span\", \"style\": {\"fontSize\": \"smaller\", \"verticalAlign\": \"bottom\"}, \"content\": \"";
 				fnCloseReplace = "\"}, \"";
 			}
 			else if (tagType == "sup")
 			{
 				// Superscript
-				fnOpenReplace = "\", {\"tag\": \"span\", \"style\": {\"fontSize\": \"x-small\", \"verticalAlign\": \"super\"}, \"content\": \"";
+				fnOpenReplace = "\", {\"tag\": \"span\", \"style\": {\"fontSize\": \"smaller\", \"verticalAlign\": \"super\"}, \"content\": \"";
 				fnCloseReplace =  "\"}, \"";
 			}
 			else if (tagType == "i")

--- a/koj72yomi.cpp
+++ b/koj72yomi.cpp
@@ -716,13 +716,13 @@ int main()
 					// There is no way to detect what kanji the furigana should go over, so doing this instead
 					//		See: わそう‐コート 【和装コート】
 					// Example where having rubi formatting is important アートマン 【ātman 梵】
-					fnOpenReplace = "\", {\"tag\": \"span\", \"style\": {\"fontSize\": \"smaller\", \"verticalAlign\": \"bottom\"}, \"content\": \"";
+					fnOpenReplace = "\", {\"tag\": \"span\", \"style\": {\"fontSize\": \"60%\", \"verticalAlign\": \"bottom\"}, \"content\": \"";
 					fnCloseReplace = "\"}, \"";
 				}
 				else if (tagAttributes == "")
 				{
 					// Plain ol subscript. Technically making this `bottom`, not sub (to match rubi)
-					fnOpenReplace = "\", {\"tag\": \"span\", \"style\": {\"fontSize\": \"smaller\", \"verticalAlign\": \"bottom\"}, \"content\": \"";
+					fnOpenReplace = "\", {\"tag\": \"span\", \"style\": {\"fontSize\": \"60%\", \"verticalAlign\": \"bottom\"}, \"content\": \"";
 					fnCloseReplace = "\"}, \"";
 				}
 			}
@@ -730,13 +730,13 @@ int main()
 			{
 				// Seems to be used exactly the same as the sub with no attributes
 				// Fun Fact: literally the only two entries that have this are LC50 and LD50
-				fnOpenReplace = "\", {\"tag\": \"span\", \"style\": {\"fontSize\": \"smaller\", \"verticalAlign\": \"bottom\"}, \"content\": \"";
+				fnOpenReplace = "\", {\"tag\": \"span\", \"style\": {\"fontSize\": \"60%\", \"verticalAlign\": \"bottom\"}, \"content\": \"";
 				fnCloseReplace = "\"}, \"";
 			}
 			else if (tagType == "sup")
 			{
 				// Superscript
-				fnOpenReplace = "\", {\"tag\": \"span\", \"style\": {\"fontSize\": \"smaller\", \"verticalAlign\": \"super\"}, \"content\": \"";
+				fnOpenReplace = "\", {\"tag\": \"span\", \"style\": {\"fontSize\": \"60%\", \"verticalAlign\": \"super\"}, \"content\": \"";
 				fnCloseReplace =  "\"}, \"";
 			}
 			else if (tagType == "i")


### PR DESCRIPTION
Text elements with absolute `font-size` properties will not scale in size with other text elements in the Yomichan popup when Yomichan's zoom setting is adjusted. I suggest using a relative font size such as `smaller` rather than the absolute size `x-small`.

See also:
https://github.com/FooSoft/yomichan/pull/2203
https://developer.mozilla.org/en-US/docs/Web/CSS/font-size